### PR TITLE
Add local and store version infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,15 @@ FutureBuilder<bool>(
 );
 ```
 
+## Accessing store and local versions
+
+Your can use the `localVersion` or `storeVersion` getters to access the current version status of your app!  
+```dart 
+final siren = Siren();
+
+final local = siren.localVersion;
+final store = siren.storeVersion;
+```
+
 ## Inspiration
 These awesome packages: [Siren](https://github.com/ArtSabintsev/Siren) and [react-native-siren](https://github.com/GantMan/react-native-siren)

--- a/example/main.dart
+++ b/example/main.dart
@@ -33,6 +33,12 @@ class MyApp extends StatelessWidget {
                     child: const Text('Check Update'),
                     onPressed: () => siren.promptUpdate(context),
                   )
+                  Text(
+                    'Local Version: ${siren.localVersion}',
+                  ),
+                  Text(
+                    'Store Version: ${siren.storeVersion}',
+                  ),
                 ],
               ),
             ),

--- a/example/main.dart
+++ b/example/main.dart
@@ -34,10 +34,10 @@ class MyApp extends StatelessWidget {
                     onPressed: () => siren.promptUpdate(context),
                   )
                   Text(
-                    'Local Version: ${siren.localVersion}',
+                    'Local Version: ${await siren.localVersion}',
                   ),
                   Text(
-                    'Store Version: ${siren.storeVersion}',
+                    'Store Version: ${await siren.storeVersion}',
                   ),
                 ],
               ),

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_siren/flutter_siren.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -35,27 +36,31 @@ class MyApp extends StatelessWidget {
                   ),
                   FutureBuilder(
                     builder: (context, snapshot) {
-                      if (ConnectionState.active != null && !snapshot.hasData) {
-                        return const Center(child: Text('Loading'));
+                      if (snapshot.hasData) {
+                        return Text(
+                            'Local Version: ${snapshot.data.toString()}');
+                      } else if (snapshot.hasError) {
+                        return Center(
+                            child: Text(snapshot.error?.toString() ?? "Error"));
+                      } else {
+                        return const Center(
+                            child: Text('Local Version: Loading...'));
                       }
-                      if (ConnectionState.done != null && snapshot.hasError) {
-                        return const Center(child: Text(snapshot.error));
-                      }
-
-                      return Text('Local Version: ${snapshot.data.toString()}')
                     },
                     future: siren.localVersion,
                   ),
                   FutureBuilder(
                     builder: (context, snapshot) {
-                      if (ConnectionState.active != null && !snapshot.hasData) {
-                        return const Center(child: Text('Loading...'));
+                      if (snapshot.hasData) {
+                        return Text(
+                            'Store Version: ${snapshot.data.toString()}');
+                      } else if (snapshot.hasError) {
+                        return Center(
+                            child: Text(snapshot.error?.toString() ?? "Error"));
+                      } else {
+                        return const Center(
+                            child: Text('Store Version: Loading...'));
                       }
-                      if (ConnectionState.done != null && snapshot.hasError) {
-                        return const Center(child: Text(snapshot.error));
-                      }
-
-                      return Text('Store Version: ${snapshot.data.toString()}')
                     },
                     future: siren.storeVersion,
                   ),

--- a/example/main.dart
+++ b/example/main.dart
@@ -33,11 +33,31 @@ class MyApp extends StatelessWidget {
                     child: const Text('Check Update'),
                     onPressed: () => siren.promptUpdate(context),
                   ),
-                  Text(
-                    'Local Version: ${await siren.localVersion}',
+                  FutureBuilder(
+                    builder: (context, snapshot) {
+                      if (ConnectionState.active != null && !snapshot.hasData) {
+                        return const Center(child: Text('Loading'));
+                      }
+                      if (ConnectionState.done != null && snapshot.hasError) {
+                        return const Center(child: Text(snapshot.error));
+                      }
+
+                      return Text('Local Version: ${snapshot.data.toString()}')
+                    },
+                    future: siren.localVersion,
                   ),
-                  Text(
-                    'Store Version: ${await siren.storeVersion}',
+                  FutureBuilder(
+                    builder: (context, snapshot) {
+                      if (ConnectionState.active != null && !snapshot.hasData) {
+                        return const Center(child: Text('Loading...'));
+                      }
+                      if (ConnectionState.done != null && snapshot.hasError) {
+                        return const Center(child: Text(snapshot.error));
+                      }
+
+                      return Text('Store Version: ${snapshot.data.toString()}')
+                    },
+                    future: siren.storeVersion,
                   ),
                 ],
               ),

--- a/lib/src/services/siren_google_play_store.dart
+++ b/lib/src/services/siren_google_play_store.dart
@@ -24,8 +24,3 @@ class SirenGooglePlayStore implements SirenStoreService<SirenStoreResponse> {
     return SirenStoreResponse(version: version, package: from, url: url);
   }
 }
-/*
-Current Version</div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">21.6.5
-Current Version</div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">1.25.0</span>
-Current Version</div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">4.4.8
-*/

--- a/lib/src/services/siren_google_play_store.dart
+++ b/lib/src/services/siren_google_play_store.dart
@@ -11,8 +11,9 @@ class SirenGooglePlayStore implements SirenStoreService<SirenStoreResponse> {
     final url = 'https://play.google.com/store/apps/details?id=$from&hl=en';
     final response = await client.get(Uri.parse(url));
 
-    final match = RegExp(r'Current Version.+>([\d.]{1,20})(?=<\/span>)')
-        .firstMatch(response.body);
+    final match =
+        RegExp(r'Current Version.+>([\d.]{1,20})(?=<\/span><\/div><\/span>)')
+            .firstMatch(response.body);
 
     if (match == null) {
       return SirenStoreResponse(version: '', package: '', url: url);
@@ -23,3 +24,8 @@ class SirenGooglePlayStore implements SirenStoreService<SirenStoreResponse> {
     return SirenStoreResponse(version: version, package: from, url: url);
   }
 }
+/*
+Current Version</div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">21.6.5
+Current Version</div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">1.25.0</span>
+Current Version</div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">4.4.8
+*/

--- a/lib/src/siren.dart
+++ b/lib/src/siren.dart
@@ -27,6 +27,7 @@ class Siren {
     throw UnimplementedError('This lib only supports Android, iOS and MacOS');
   }
 
+  /// This method will get the local version downloaded of your app.
   Future<Version> get storeVersion async {
     final packageInfo = await PackageInfo.fromPlatform();
     _response =
@@ -34,6 +35,7 @@ class Siren {
     return Version.parse(_response.version);
   }
 
+  /// This method will get the store version of your app.
   Future<Version> get localVersion async {
     final packageInfo = await PackageInfo.fromPlatform();
     final currentVersion = packageInfo.version;

--- a/lib/src/siren.dart
+++ b/lib/src/siren.dart
@@ -44,17 +44,10 @@ class Siren {
 
   /// This method checks for an update in the application store and returns if there is a newer version than the local one.
   Future<bool> updateIsAvailable() async {
-    final packageInfo = await PackageInfo.fromPlatform();
+    final localVer = await localVersion;
+    final storeVer = await storeVersion;
 
-    final currentVersion = packageInfo.version;
-    final packageName = packageInfo.packageName;
-
-    _response = await _getStoreClient().getStoreResponse(from: packageName);
-
-    final updateIsAvailable =
-        Version.parse(_response.version) > Version.parse(currentVersion);
-
-    return updateIsAvailable;
+    return storeVer > localVer;
   }
 
   /// This method shows an customizable AlertDialog if an update is available.

--- a/lib/src/siren.dart
+++ b/lib/src/siren.dart
@@ -27,6 +27,19 @@ class Siren {
     throw UnimplementedError('This lib only supports Android, iOS and MacOS');
   }
 
+  Future<Version> get storeVersion async {
+    final packageInfo = await PackageInfo.fromPlatform();
+    _response =
+        await _getStoreClient().getStoreResponse(from: packageInfo.packageName);
+    return Version.parse(_response.version);
+  }
+
+  Future<Version> get localVersion async {
+    final packageInfo = await PackageInfo.fromPlatform();
+    final currentVersion = packageInfo.version;
+    return Version.parse(currentVersion);
+  }
+
   /// This method checks for an update in the application store and returns if there is a newer version than the local one.
   Future<bool> updateIsAvailable() async {
     final packageInfo = await PackageInfo.fromPlatform();


### PR DESCRIPTION
Hi there!

First of, thanks for this package it's really nice! 😄 

I was about to use your package on our project but I was missing some things. In the project I'm working on, we needed one pretty specific way to handle update pop up. The project needs to popup the prompt alert only when a minor change is posed, but on a bugfix, we needed to force update the user.

So basically we wanted to implement our own custom `updateIsAvailable` with differents states. So what I would want for this package is to have a way to go fetch the store version the same way it's done internally. Also, for the sack of consistency, I added a `localVersion` getter to access the current downloaded version.

The only thing missing from this PR is maybe an actual test as I'm not sure how to test a dart package like this in an app properly. Don't know if you have something to test against on your side? Just to make sure the feature works.

Hopes my addition are up to standard, and again a big thanks for this package 😄

Don't hesitate to contact me for any questions on this PR,
Sam